### PR TITLE
fix: convert cid before instanceof check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [14, 15]
+        node: [14, 16]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/ipfs/js-blockstore-datastore-adapter#readme",
   "devDependencies": {
-    "aegir": "^33.1.0",
+    "aegir": "^35.0.2",
     "interface-blockstore-tests": "^1.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "homepage": "https://github.com/ipfs/js-blockstore-datastore-adapter#readme",
   "devDependencies": {
     "aegir": "^35.0.2",
-    "interface-blockstore-tests": "^1.0.0"
+    "interface-blockstore-tests": "^1.0.0",
+    "util": "^0.12.4"
   },
   "dependencies": {
     "err-code": "^3.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -18,11 +18,13 @@ const { BlockstoreAdapter } = require('interface-blockstore')
  * @returns {Key}
  */
 function cidToKey (cid) {
-  if (!(cid instanceof CID)) {
+  const c = CID.asCID(cid)
+
+  if (!(c instanceof CID)) {
     throw errcode(new Error('Not a valid cid'), 'ERR_INVALID_CID')
   }
 
-  return new Key('/' + base32.encode(cid.multihash.bytes).slice(1).toUpperCase(), false)
+  return new Key('/' + base32.encode(c.multihash.bytes).slice(1).toUpperCase(), false)
 }
 
 /**


### PR DESCRIPTION
The `CID` class can be loaded as an ESM or a CJS class which means
`instanceof` breaks since they are loaded from different places.

Run the passed `cid` through `CID.asCID` to convert it to whatever
we think the `CID` class is before the test.